### PR TITLE
Print actual phase name instead of alpha1.

### DIFF
--- a/applications/solvers/multiphase/interFoam/alphaEqn.H
+++ b/applications/solvers/multiphase/interFoam/alphaEqn.H
@@ -47,8 +47,8 @@
 
         Info<< "Phase-1 volume fraction = "
             << alpha1.weightedAverage(mesh.Vsc()).value()
-            << "  Min(alpha1) = " << min(alpha1).value()
-            << "  Max(alpha1) = " << max(alpha1).value()
+            << "  Min(" << alpha1.name() <<") = " << min(alpha1).value()
+            << "  Max(" << alpha1.name() <<") = " << max(alpha1).value()
             << endl;
 
         tmp<surfaceScalarField> tphiAlphaUD(alpha1Eqn.flux());
@@ -144,7 +144,7 @@
 
     Info<< "Phase-1 volume fraction = "
         << alpha1.weightedAverage(mesh.Vsc()).value()
-        << "  Min(alpha1) = " << min(alpha1).value()
-        << "  Max(alpha1) = " << max(alpha1).value()
+        << "  Min(" << alpha1.name() <<") = " << min(alpha1).value()
+        << "  Max(" << alpha1.name() <<") = " << max(alpha1).value()
         << endl;
 }


### PR DESCRIPTION
As new version of interFoam supports phase naming, use actual phase name in the printout.