### PR TITLE
Fixed wcleanAll to use recent xargs params

### DIFF
--- a/wmake/wcleanAll
+++ b/wmake/wcleanAll
@@ -66,7 +66,7 @@ find . -name '*.dep' -exec rm {} \;
 
 echo "Cleaning Make subdirectories"
 find . -depth \( -name Make -o -name "Make.[A-Za-z]*" \) -type d -print | \
-    xargs -i find '{}' -mindepth 1 -maxdepth 1 -type d -print | \
+    xargs -I {} find '{}' -mindepth 1 -maxdepth 1 -type d -print | \
     xargs rm -rf
 
 echo "Removing lnInclude and intermediate directories"


### PR DESCRIPTION
Replaced 'xargs -i' with 'xargs -I', since the former does not work on the Mac and is considered deprecated per the Linux man page.